### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/lwt-dllist.opam
+++ b/lwt-dllist.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/mirage/lwt-dllist/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "lwt"
-  "dune" {build}
+  "dune"
 ]
 build: [
  ["dune" "subst" ] {pinned}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.